### PR TITLE
DoT and Snare no longer throw errors when the target dies Closes #37

### DIFF
--- a/Assets/Resources/scripts/effects/DoTEffect.cs
+++ b/Assets/Resources/scripts/effects/DoTEffect.cs
@@ -11,8 +11,15 @@ public class DoTEffect : Effect {
 	protected override void ApplyEffect() {
 		// Apply damage to the target (will happen once per tick)
 
-		targetHealthScript = target.GetComponent<HealthScript>();	// Damage() is part of HealthScript
+		if(target) {
+			// Check if target is still alive
+			targetHealthScript = target.GetComponent<HealthScript>();	// Damage() is part of HealthScript
 
-		targetHealthScript.Damage(amount);	// Apply damage to the target (mitigation is handled by HealthScript)
+			targetHealthScript.Damage(amount);	// Apply damage to the target (mitigation is handled by HealthScript)
+		}
+		else {
+			// Target is dead, get rid of the DoT
+			base.EndEffect();
+		}
 	}
 }

--- a/Assets/Resources/scripts/effects/SnareEffect.cs
+++ b/Assets/Resources/scripts/effects/SnareEffect.cs
@@ -9,11 +9,16 @@ public class SnareEffect : Effect {
 	private MoveScript targetMoveScript;	// The target's movement script
 	
 	protected override void ApplyEffect() {
-		// Apply the snare to the target
+		if(target) {
+			// Apply the snare to the target
+			targetMoveScript = target.GetComponent<MoveScript>();	// Movespeed is set on MoveScript
 
-		targetMoveScript = target.GetComponent<MoveScript>();	// Movespeed is set on MoveScript
-
-		targetMoveScript.speed *= amount;	// Reduce the target's movement script by a percentage
+			targetMoveScript.speed *= amount;	// Reduce the target's movement script by a percentage
+		}
+		else {
+			// Target is dead, get rid of effect
+			base.EndEffect();
+		}
 	}
 
 	protected override void EndEffect() {


### PR DESCRIPTION
DoT/Snare only apply effects if target is still alive.

@radjaffo ready for review/merge!
