### PR TITLE
Adjusted keys to make it easier to play without mouse

### DIFF
--- a/Assets/Resources/prefabs/characters/players/Player.prefab
+++ b/Assets/Resources/prefabs/characters/players/Player.prefab
@@ -453,7 +453,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7e00a03c1e95f4cb0a833a36a0e378e9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  abilityKeys: 7100000077000000
+  abilityKeys: 7100000065000000
+  attackKey: 32
   pauseKey: 27
 --- !u!131 &13100000
 GUITexture:

--- a/Assets/Resources/scripts/characters/player/PlayerScript.cs
+++ b/Assets/Resources/scripts/characters/player/PlayerScript.cs
@@ -6,6 +6,7 @@ public class PlayerScript : MonoBehaviour {
 
 	// Hotkeys
 	public KeyCode[] abilityKeys = new KeyCode[2];
+	public KeyCode attackKey;
 	public KeyCode pauseKey;
 
 	// Components
@@ -39,6 +40,7 @@ public class PlayerScript : MonoBehaviour {
 		// Retrieve button information from mouse
 		bool attack = Input.GetButtonDown("Fire1");
 		attack |= Input.GetButtonDown("Fire2");
+		attack |= Input.GetKeyDown (attackKey);
 
 		// Watch for ability input
 		bool ability1 = Input.GetKeyDown(abilityKeys[0]);


### PR DESCRIPTION
I moved the keys around a bit to the following configuration:

**WASD** - Still work as movement keys

**Q/E** - Use ability 1/2

**Spacebar** - Swing sword

This allows you to play without having a hand on the mouse which is nice.
